### PR TITLE
[고도화] 엔티티 코드 리팩토링 - 엔티티 equals(), hashcode() 비교 로직에 getter 바꾸기

### DIFF
--- a/src/main/java/com/boardProject/domain/Article.java
+++ b/src/main/java/com/boardProject/domain/Article.java
@@ -54,11 +54,11 @@ public class Article extends AuditingFields {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         Article article = (Article) o;
-        return Objects.equals(id, article.id);
+        return Objects.equals(this.getId(), article.id);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id);
+        return Objects.hash(this.getId());
     }
 }

--- a/src/main/java/com/boardProject/domain/ArticleComment.java
+++ b/src/main/java/com/boardProject/domain/ArticleComment.java
@@ -43,11 +43,11 @@ public class ArticleComment extends AuditingFields {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         ArticleComment that = (ArticleComment) o;
-        return Objects.equals(id, that.id);
+        return Objects.equals(this.getId(), that.id);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id);
+        return Objects.hash(this.getId());
     }
 }

--- a/src/main/java/com/boardProject/domain/UserAccount.java
+++ b/src/main/java/com/boardProject/domain/UserAccount.java
@@ -45,11 +45,11 @@ public class UserAccount extends AuditingFields {
     public boolean equals(Object o) {
         if (this == o) return true;
         if (!(o instanceof UserAccount userAccount)) return false;
-        return userId != null && userId.equals(userAccount.userId);
+        return this.getUserId() != null && this.getUserId().equals(userAccount.userId);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(userId);
+        return Objects.hash(this.getUserId());
     }
 }


### PR DESCRIPTION
이 PR은 엔티티의 `equals()`, `hashcode()`가 값 비교를 하기 위해 필드 직접 접근하는 것을 getter 접근으로 바꾼다.
프록시 객체를 사용하는 하이버네이트의 지연 로딩을 고려하여, 값 비교를 제대로 수행하지 못하는 일이 없도록 한다.

This closes #73 